### PR TITLE
Adding arguments to copy the lzo1x libraries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,4 +22,6 @@ setup(
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
   ],
+  package_dir={'pygbx': 'pygbx'},
+  package_data={'pygbx': ['lzo/libs/lzo1x.*']},
 )


### PR DESCRIPTION
If we don't add those, we have to copy the libraries manually. Now with that, they are automatically added in the pygbx folder